### PR TITLE
Completely rewrite ThreadPool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,21 @@
 # ThreadPool
 Lightweight, Generic, Pure C++11 ThreadPool
 
-## Rational
-I needed a Thread Pool for something I was writing, and I didn't see any that I liked. This is still somewhat a work in progress; it's stable, but there are probably places where some of the locking logic could be better. `ThreadPool::JoinAll` is a little sloppy, but it works. 
-
-## Licensing 
-Public Domain. If my licensing is wrong, please let me know. Use at your own risk for whatever you want. Feel free to change the namespaces as well. Apparently licensing is hard and complicated. If your country doesn't have a public domain, feel free to say you found this on the side of the road. 
+## Licensing
+Public Domain. Use at your own risk for whatever you want. If your country doesn't have a public domain, feel free to say you found this on the side of the road. 
 
 ## Overview
-`ThreadPool` is a super simple class that manages threads and jobs. `ThreadCount` threads are created at object instantiation time, and persist until the `ThreadPool` object is destroyed. You cannot change the thread count. A later version may allow you to set the thread count through the constructor rather than as a template parameter, but it's not something I care to do at the moment. Jobs are functions with no parameters or return values. This decision was to make it as generic as possible so it could be integrated into a variety of projects. If you can't get your job to work with those constraints, you're doing something wrong, or you need to roll your own ThreadPool. But you're probably making things overly complicated.
+`ThreadPool` is a super simple class that manages threads and jobs. `threadCount` threads are created at object instantiation time, and persist until the `ThreadPool` object is destroyed. You cannot change the thread count. Jobs are functions with no parameters or return values. This decision was to make it as generic as possible so it could be integrated into a variety of projects. If you can't get your job to work with those constraints, you're doing something wrong, or you need to roll your own ThreadPool. But you're probably making things overly complicated.
 
 Below is a quick overview, but ThreadPool.h is documented, so just read that. It's less than 200 lines with comments.
 
 ```c++
-template <unsigned ThreadCount = 10>
 class ThreadPool {
 public:
-    ThreadPool();
+    ThreadPool(int threadCount);
     ~ThreadPool();
-    void AddJob( std::function<void(void)> );
-    unsigned Size() const;
-    unsigned JobsRemaining();
-    void JoinAll( bool WaitForAll = true );
+    void AddJob(std::function<void(void)> job);
+    void JoinAll();
     void WaitAll();
 };
 ```
@@ -34,15 +28,13 @@ public:
 #include <chrono>
 
 int main() {
-    using nbsdx::concurrent::ThreadPool;
-    
-    ThreadPool pool; // Defaults to 10 threads.
+    ThreadPool pool(10); // Creates 10 threads.
     int JOB_COUNT = 100;
     
-    for( int i = 0; i < JOB_COUNT; ++i )
-        pool.AddJob( []() { 
-            std::this_thread::sleep_for( std::chrono::seconds( 1 ) );
-        } );
+    for (int i = 0; i < JOB_COUNT; ++i)
+        pool.AddJob([]() { 
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        });
     
     pool.JoinAll();
     std::cout << "Expected runtime: 10 seconds." << std::endl;
@@ -51,12 +43,12 @@ int main() {
 
 Convience Function for running a list of jobs in a pool, assuming the type being iterated is of `std::function<void(void)>`:
 ```c++
-template <typename Iter, unsigned Count = 10>
-void RunInPool( Iter begin, Iter end ) {
-    ThreadPool<Count> pool;
-    for( ; begin != end; begin = std::next( begin ) )
-        pool.AddJob( *begin );
+template <typename Iter>
+void RunInPool(Iter begin, Iter end, int threadCount) {
+    ThreadPool pool(threadCount);
+    for( ; begin != end; begin = std::next(begin))
+        pool.AddJob(*begin);
     pool.JoinAll();
 }
 ```
-It's worth nothing that the `pool.JoinAll();` is optional in this example, since `JoinAll` is invoked upon object deconstruction. 
+It's worth nothing that `pool.JoinAll();` is optional in this example, since `JoinAll` is invoked upon object deconstruction. 

--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -1,159 +1,169 @@
 #ifndef CONCURRENT_THREADPOOL_H
 #define CONCURRENT_THREADPOOL_H
 
-#include <atomic>
 #include <thread>
 #include <mutex>
-#include <array>
-#include <list>
 #include <functional>
 #include <condition_variable>
-
-namespace nbsdx {
-namespace concurrent {
+#include <queue>
 
 /**
- *  Simple ThreadPool that creates `ThreadCount` threads upon its creation,
- *  and pulls from a queue to get new jobs. The default is 10 threads.
+ *  Simple ThreadPool that creates `threadCount` threads upon its creation,
+ *  and pulls from a queue to get new jobs.
  *
  *  This class requires a number of c++11 features be present in your compiler.
  */
-template <unsigned ThreadCount = 10>
-class ThreadPool {
-    
-    std::array<std::thread, ThreadCount> threads;
-    std::list<std::function<void(void)>> queue;
-
-    std::atomic_int         jobs_left;
-    std::atomic_bool        bailout;
-    std::atomic_bool        finished;
-    std::condition_variable job_available_var;
-    std::condition_variable wait_var;
-    std::mutex              wait_mutex;
-    std::mutex              queue_mutex;
-
-    /**
-     *  Take the next job in the queue and run it.
-     *  Notify the main thread that a job has completed.
-     */
-    void Task() {
-        while( !bailout ) {
-            next_job()();
-            --jobs_left;
-            wait_var.notify_one();
-        }
-    }
-
-    /**
-     *  Get the next job; pop the first item in the queue, 
-     *  otherwise wait for a signal from the main thread.
-     */
-    std::function<void(void)> next_job() {
-        std::function<void(void)> res;
-        std::unique_lock<std::mutex> job_lock( queue_mutex );
-
-        // Wait for a job if we don't have any.
-        job_available_var.wait( job_lock, [this]() ->bool { return queue.size() || bailout; } );
-        
-        // Get job from the queue
-        if( !bailout ) {
-            res = queue.front();
-            queue.pop_front();
-        }
-        else { // If we're bailing out, 'inject' a job into the queue to keep jobs_left accurate.
-            res = []{};
-            ++jobs_left;
-        }
-        return res;
-    }
-
+class ThreadPool
+{
 public:
-    ThreadPool()
-        : jobs_left( 0 )
-        , bailout( false )
-        , finished( false ) 
-    {
-        for( unsigned i = 0; i < ThreadCount; ++i )
-            threads[ i ] = std::move( std::thread( [this,i]{ this->Task(); } ) );
-    }
+	explicit ThreadPool(int threadCount) :
+		_jobsLeft(0),
+		_bailout(false)
+	{
+		_threads = std::vector<std::thread>(threadCount);
 
-    /**
-     *  JoinAll on deconstruction
-     */
-    ~ThreadPool() {
-        JoinAll();
-    }
+		for (int index = 0; index < threadCount; ++index)
+		{
+			_threads[index] = std::move(std::thread([this]
+				{
+					this->Task();
+				}));
+		}
+	}
 
-    /**
-     *  Get the number of threads in this pool
-     */
-    inline unsigned Size() const {
-        return ThreadCount;
-    }
+	/**
+	 *  JoinAll on deconstruction
+	 */
+	~ThreadPool()
+	{
+		JoinAll();
+	}
 
-    /**
-     *  Get the number of jobs left in the queue.
-     */
-    inline unsigned JobsRemaining() {
-        std::lock_guard<std::mutex> guard( queue_mutex );
-        return queue.size();
-    }
+	/**
+	 *  Add a new job to the pool. If there are no jobs in the queue,
+	 *  a thread is woken up to take the job. If all threads are busy,
+	 *  the job is added to the end of the queue.
+	 */
+	void AddJob(std::function<void(void)> job)
+	{
+		// scoped lock
+		{
+			std::lock_guard<std::mutex> lock(_queueMutex);
+			_queue.emplace(job);
+		}
+		// scoped lock
+		{
+			std::lock_guard<std::mutex> lock(_jobsLeftMutex);
+			++_jobsLeft;
+		}
+		_jobAvailableVar.notify_one();
+	}
 
-    /**
-     *  Add a new job to the pool. If there are no jobs in the queue,
-     *  a thread is woken up to take the job. If all threads are busy,
-     *  the job is added to the end of the queue.
-     */
-    void AddJob( std::function<void(void)> job ) {
-        std::lock_guard<std::mutex> guard( queue_mutex );
-        queue.emplace_back( job );
-        ++jobs_left;
-        job_available_var.notify_one();
-    }
+	/**
+	 *  Join with all threads. Block until all threads have completed.
+	 *  The queue may be filled after this call, but the threads will
+	 *  be done. After invoking `ThreadPool::JoinAll`, the pool can no
+	 *  longer be used.
+	 */
+	void JoinAll()
+	{
+		// scoped lock
+		{
+			std::lock_guard<std::mutex> lock(_queueMutex);
+			if (_bailout)
+			{
+				return;
+			}
+			_bailout = true;
+		}
 
-    /**
-     *  Join with all threads. Block until all threads have completed.
-     *  Params: WaitForAll: If true, will wait for the queue to empty 
-     *          before joining with threads. If false, will complete
-     *          current jobs, then inform the threads to exit.
-     *  The queue will be empty after this call, and the threads will
-     *  be done. After invoking `ThreadPool::JoinAll`, the pool can no
-     *  longer be used. If you need the pool to exist past completion
-     *  of jobs, look to use `ThreadPool::WaitAll`.
-     */
-    void JoinAll( bool WaitForAll = true ) {
-        if( !finished ) {
-            if( WaitForAll ) {
-                WaitAll();
-            }
+		// note that we're done, and wake up any thread that's
+		// waiting for a new job
+		_jobAvailableVar.notify_all();
 
-            // note that we're done, and wake up any thread that's
-            // waiting for a new job
-            bailout = true;
-            job_available_var.notify_all();
+		for (auto& x : _threads)
+		{
+			if (x.joinable())
+			{
+				x.join();
+			}
+		}
+	}
 
-            for( auto &x : threads )
-                if( x.joinable() )
-                    x.join();
-            finished = true;
-        }
-    }
+	/**
+	 *  Wait for the pool to empty before continuing.
+	 *  This does not call `std::thread::join`, it only waits until
+	 *  all jobs have finished executing.
+	 */
+	void WaitAll()
+	{
+		std::unique_lock<std::mutex> lock(_jobsLeftMutex);
+		if (_jobsLeft > 0)
+		{
+			_waitVar.wait(lock, [this]
+			              {
+				              return _jobsLeft == 0;
+			              });
+		}
+	}
 
-    /**
-     *  Wait for the pool to empty before continuing. 
-     *  This does not call `std::thread::join`, it only waits until
-     *  all jobs have finshed executing.
-     */
-    void WaitAll() {
-        if( jobs_left > 0 ) {
-            std::unique_lock<std::mutex> lk( wait_mutex );
-            wait_var.wait( lk, [this]{ return this->jobs_left == 0; } );
-            lk.unlock();
-        }
-    }
+private:
+	/**
+	 *  Take the next job in the queue and run it.
+	 *  Notify the main thread that a job has completed.
+	 */
+	void Task()
+	{
+		while (true)
+		{
+			std::function<void(void)> job;
+
+			// scoped lock
+			{
+				std::unique_lock<std::mutex> lock(_queueMutex);
+
+				if (_bailout)
+				{
+					return;
+				}
+
+				// Wait for a job if we don't have any.
+				_jobAvailableVar.wait(lock, [this]
+				                      {
+					                      return _queue.size() > 0 || _bailout;
+				                      });
+
+				if (_bailout)
+				{
+					return;
+				}
+
+				// Get job from the queue
+				job = _queue.front();
+				_queue.pop();
+			}
+
+			job();
+
+			// scoped lock
+			{
+				std::lock_guard<std::mutex> lock(_jobsLeftMutex);
+				--_jobsLeft;
+			}
+
+			_waitVar.notify_one();
+		}
+	}
+
+	std::vector<std::thread> _threads;
+	std::queue<std::function<void(void)>> _queue;
+
+	int _jobsLeft;
+	bool _bailout;
+	std::condition_variable _jobAvailableVar;
+	std::condition_variable _waitVar;
+	std::mutex _jobsLeftMutex;
+	std::mutex _queueMutex;
 };
-
-} // namespace concurrent
-} // namespace nbsdx
 
 #endif //CONCURRENT_THREADPOOL_H

--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -16,154 +16,154 @@
 class ThreadPool
 {
 public:
-	explicit ThreadPool(int threadCount) :
-		_jobsLeft(0),
-		_bailout(false)
-	{
-		_threads = std::vector<std::thread>(threadCount);
+    explicit ThreadPool(int threadCount) :
+        _jobsLeft(0),
+        _bailout(false)
+    {
+        _threads = std::vector<std::thread>(threadCount);
 
-		for (int index = 0; index < threadCount; ++index)
-		{
-			_threads[index] = std::move(std::thread([this]
-				{
-					this->Task();
-				}));
-		}
-	}
+        for (int index = 0; index < threadCount; ++index)
+        {
+            _threads[index] = std::move(std::thread([this]
+                {
+                    this->Task();
+                }));
+        }
+    }
 
-	/**
-	 *  JoinAll on deconstruction
-	 */
-	~ThreadPool()
-	{
-		JoinAll();
-	}
+    /**
+     *  JoinAll on deconstruction
+     */
+    ~ThreadPool()
+    {
+        JoinAll();
+    }
 
-	/**
-	 *  Add a new job to the pool. If there are no jobs in the queue,
-	 *  a thread is woken up to take the job. If all threads are busy,
-	 *  the job is added to the end of the queue.
-	 */
-	void AddJob(std::function<void(void)> job)
-	{
-		// scoped lock
-		{
-			std::lock_guard<std::mutex> lock(_queueMutex);
-			_queue.emplace(job);
-		}
-		// scoped lock
-		{
-			std::lock_guard<std::mutex> lock(_jobsLeftMutex);
-			++_jobsLeft;
-		}
-		_jobAvailableVar.notify_one();
-	}
+    /**
+     *  Add a new job to the pool. If there are no jobs in the queue,
+     *  a thread is woken up to take the job. If all threads are busy,
+     *  the job is added to the end of the queue.
+     */
+    void AddJob(std::function<void(void)> job)
+    {
+        // scoped lock
+        {
+            std::lock_guard<std::mutex> lock(_queueMutex);
+            _queue.emplace(job);
+        }
+        // scoped lock
+        {
+            std::lock_guard<std::mutex> lock(_jobsLeftMutex);
+            ++_jobsLeft;
+        }
+        _jobAvailableVar.notify_one();
+    }
 
-	/**
-	 *  Join with all threads. Block until all threads have completed.
-	 *  The queue may be filled after this call, but the threads will
-	 *  be done. After invoking `ThreadPool::JoinAll`, the pool can no
-	 *  longer be used.
-	 */
-	void JoinAll()
-	{
-		// scoped lock
-		{
-			std::lock_guard<std::mutex> lock(_queueMutex);
-			if (_bailout)
-			{
-				return;
-			}
-			_bailout = true;
-		}
+    /**
+     *  Join with all threads. Block until all threads have completed.
+     *  The queue may be filled after this call, but the threads will
+     *  be done. After invoking `ThreadPool::JoinAll`, the pool can no
+     *  longer be used.
+     */
+    void JoinAll()
+    {
+        // scoped lock
+        {
+            std::lock_guard<std::mutex> lock(_queueMutex);
+            if (_bailout)
+            {
+                return;
+            }
+            _bailout = true;
+        }
 
-		// note that we're done, and wake up any thread that's
-		// waiting for a new job
-		_jobAvailableVar.notify_all();
+        // note that we're done, and wake up any thread that's
+        // waiting for a new job
+        _jobAvailableVar.notify_all();
 
-		for (auto& x : _threads)
-		{
-			if (x.joinable())
-			{
-				x.join();
-			}
-		}
-	}
+        for (auto& x : _threads)
+        {
+            if (x.joinable())
+            {
+                x.join();
+            }
+        }
+    }
 
-	/**
-	 *  Wait for the pool to empty before continuing.
-	 *  This does not call `std::thread::join`, it only waits until
-	 *  all jobs have finished executing.
-	 */
-	void WaitAll()
-	{
-		std::unique_lock<std::mutex> lock(_jobsLeftMutex);
-		if (_jobsLeft > 0)
-		{
-			_waitVar.wait(lock, [this]
-			              {
-				              return _jobsLeft == 0;
-			              });
-		}
-	}
+    /**
+     *  Wait for the pool to empty before continuing.
+     *  This does not call `std::thread::join`, it only waits until
+     *  all jobs have finished executing.
+     */
+    void WaitAll()
+    {
+        std::unique_lock<std::mutex> lock(_jobsLeftMutex);
+        if (_jobsLeft > 0)
+        {
+            _waitVar.wait(lock, [this]
+                          {
+                              return _jobsLeft == 0;
+                          });
+        }
+    }
 
 private:
-	/**
-	 *  Take the next job in the queue and run it.
-	 *  Notify the main thread that a job has completed.
-	 */
-	void Task()
-	{
-		while (true)
-		{
-			std::function<void(void)> job;
+    /**
+     *  Take the next job in the queue and run it.
+     *  Notify the main thread that a job has completed.
+     */
+    void Task()
+    {
+        while (true)
+        {
+            std::function<void(void)> job;
 
-			// scoped lock
-			{
-				std::unique_lock<std::mutex> lock(_queueMutex);
+            // scoped lock
+            {
+                std::unique_lock<std::mutex> lock(_queueMutex);
 
-				if (_bailout)
-				{
-					return;
-				}
+                if (_bailout)
+                {
+                    return;
+                }
 
-				// Wait for a job if we don't have any.
-				_jobAvailableVar.wait(lock, [this]
-				                      {
-					                      return _queue.size() > 0 || _bailout;
-				                      });
+                // Wait for a job if we don't have any.
+                _jobAvailableVar.wait(lock, [this]
+                                      {
+                                          return _queue.size() > 0 || _bailout;
+                                      });
 
-				if (_bailout)
-				{
-					return;
-				}
+                if (_bailout)
+                {
+                    return;
+                }
 
-				// Get job from the queue
-				job = _queue.front();
-				_queue.pop();
-			}
+                // Get job from the queue
+                job = _queue.front();
+                _queue.pop();
+            }
 
-			job();
+            job();
 
-			// scoped lock
-			{
-				std::lock_guard<std::mutex> lock(_jobsLeftMutex);
-				--_jobsLeft;
-			}
+            // scoped lock
+            {
+                std::lock_guard<std::mutex> lock(_jobsLeftMutex);
+                --_jobsLeft;
+            }
 
-			_waitVar.notify_one();
-		}
-	}
+            _waitVar.notify_one();
+        }
+    }
 
-	std::vector<std::thread> _threads;
-	std::queue<std::function<void(void)>> _queue;
+    std::vector<std::thread> _threads;
+    std::queue<std::function<void(void)>> _queue;
 
-	int _jobsLeft;
-	bool _bailout;
-	std::condition_variable _jobAvailableVar;
-	std::condition_variable _waitVar;
-	std::mutex _jobsLeftMutex;
-	std::mutex _queueMutex;
+    int _jobsLeft;
+    bool _bailout;
+    std::condition_variable _jobAvailableVar;
+    std::condition_variable _waitVar;
+    std::mutex _jobsLeftMutex;
+    std::mutex _queueMutex;
 };
 
 #endif //CONCURRENT_THREADPOOL_H


### PR DESCRIPTION
- Fixes deadlocks (in `WaitAll` and `JoinAll` specifically)
- Supports setting amount of threads in constructor
- Clearer datatypes: `queue` instead of `list`
- Removes redundancies
- Simplifies the code

More info can be found here: http://stackoverflow.com/q/37110370
