### PR TITLE
clean useless code

### DIFF
--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -74,7 +74,7 @@ public:
         , finished( false ) 
     {
         for( unsigned i = 0; i < ThreadCount; ++i )
-            threads[ i ] = std::move( std::thread( [this,i]{ this->Task(); } ) );
+            threads[ i ] = std::thread( [this]{ this->Task(); } );
     }
 
     /**


### PR DESCRIPTION
std::move is unnecessary, since std::thread only has move assignment operator.